### PR TITLE
Improve 404 for embeds

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,5 @@
+---
+layout: post
+permalink: /404.html
+version_text: 'pending...'
+---

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,8 +28,8 @@
       <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="52" y="15" fill="#010101" fill-opacity=".3">ember-versions</text>
         <text x="52" y="14">ember-versions</text>
-        <text x="138" y="15" fill="#010101" fill-opacity=".3">{{page.start_version}}{% if page.end_version %} - {{page.end_version}}{% else %}+{% endif %}</text>
-        <text x="138" y="14">{{page.start_version}}{% if page.end_version %} - {{page.end_version}}{% else %}+{% endif %}</text>
+        <text x="138" y="15" fill="#010101" fill-opacity=".3">{% if page.version_text %}{{page.version_text}}{% else %}{{page.start_version}}{% if page.end_version %} - {{page.end_version}}{% else %}+{% endif %}{% endif %}</text>
+        <text x="138" y="14">{% if page.version_text %}{{page.version_text}}{% else %}{{page.start_version}}{% if page.end_version %} - {{page.end_version}}{% else %}+{% endif %}{% endif %}</text>
       </g>
     </svg>
     </a>


### PR DESCRIPTION
Causes 404 errors to render as:

![](https://api.monosnap.com/rpc/file/download?id=DY4IvNEbCP1sbJOZeZ5PwKXa2JCMou)

Which should helps authors by having something meaningful appear before their PR is merged.
